### PR TITLE
Remove permission hammer and shrink image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,24 @@ RUN groupadd \
         --gid ${EXECUTING_USER} \
         ${EXECUTING_USER}
 
-RUN apt-get update
-RUN apt-get install -y wget unzip libjpeg-dev python-dev python-virtualenv gettext zlib1g-dev git npm nodejs nodejs-legacy python-pip
+# Chain apt-get update, apt-get install and the removal of the lists.
+# This is one of the best practices of Docker, see
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get
+RUN apt-get update \
+    && apt-get install -y \
+        wget \
+        unzip \
+        libjpeg-dev \
+        python-dev \
+        python-virtualenv \
+        gettext \
+        zlib1g-dev \
+        git \
+        npm \
+        nodejs \
+        nodejs-legacy \
+        python-pip \
+    && rm -rf /var/lib/apt/lists/*
 
 # Download fiduswriter release from github
 RUN wget -O fiduswriter.zip https://github.com/fiduswriter/fiduswriter/archive/${VERSION}.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,13 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Download fiduswriter release from github
-RUN wget -O fiduswriter.zip https://github.com/fiduswriter/fiduswriter/archive/${VERSION}.zip
-RUN unzip fiduswriter.zip
-RUN mv fiduswriter-${VERSION} /fiduswriter
+# Run the unzipping, moving and removal of zip file in the same layer.
+RUN wget \
+    --output-document=fiduswriter.zip \
+    https://github.com/fiduswriter/fiduswriter/archive/${VERSION}.zip \
+    && unzip fiduswriter.zip \
+    && mv fiduswriter-${VERSION} /fiduswriter \
+    && rm fiduswriter.zip
 
 WORKDIR "fiduswriter"
 RUN mkdir static-libs

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,7 @@ RUN pip install -r requirements.txt
 RUN python manage.py init
 
 COPY start-fiduswriter.sh /etc/start-fiduswriter.sh
-CMD sh "/etc/start-fiduswriter.sh"
+
+# Always use the array form for exec, see
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#cmd
+CMD ["/bin/sh", "/etc/start-fiduswriter.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ENV EXECUTING_GROUP_ID 999
 ENV EXECUTING_USER fiduswriter
 ENV EXECUTING_USER_ID 999
 
+# Data volume, should be owned by 999:999 to ensure the application can
+# function correctly. Run `chown 999:999 <data-dir-path>` on the host OS to
+# get this right.
 VOLUME ["/data"]
 
 # Create user and group with fixed ID, instead of allowing the OS to pick one.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,29 @@
 FROM ubuntu:16.04
 EXPOSE 8000:8000
 ENV VERSION 3.3.5
+
+# Executing group, with fixed group id
+ENV EXECUTING_GROUP fiduswriter
+ENV EXECUTING_GROUP_ID 999
+
+# Executing user, with fixed user id
 ENV EXECUTING_USER fiduswriter
+ENV EXECUTING_USER_ID 999
+
 VOLUME ["/data"]
 
-RUN groupadd --system ${EXECUTING_USER} && useradd --system --create-home --gid ${EXECUTING_USER}  ${EXECUTING_USER} 
+# Create user and group with fixed ID, instead of allowing the OS to pick one.
+RUN groupadd \
+        --system \
+        --gid ${EXECUTING_GROUP_ID} \
+        ${EXECUTING_GROUP} \
+    && useradd \
+        --system \
+        --create-home \
+         --no-log-init \
+        --uid ${EXECUTING_USER_ID} \
+        --gid ${EXECUTING_USER} \
+        ${EXECUTING_USER}
 
 RUN apt-get update
 RUN apt-get install -y wget unzip libjpeg-dev python-dev python-virtualenv gettext zlib1g-dev git npm nodejs nodejs-legacy python-pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,12 +57,10 @@ RUN wget \
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#workdir
 WORKDIR /fiduswriter
 
-RUN mkdir static-libs
-RUN cp configuration.py-default configuration.py
+RUN mkdir static-libs && \
+    cp configuration.py-default configuration.py
 
-
-RUN chmod -R 777 /data
-RUN chmod -R 777 /fiduswriter
+RUN chmod -R 777 /data /fiduswriter
 
 USER ${EXECUTING_USER}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# vim: set ts=4 sw=4 sts=0 sta et :
 FROM ubuntu:16.04
 EXPOSE 8000:8000
 ENV VERSION 3.3.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,10 @@ RUN wget \
     && mv fiduswriter-${VERSION} /fiduswriter \
     && rm fiduswriter.zip
 
-WORKDIR "fiduswriter"
+# Working directories should be absolute.
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#workdir
+WORKDIR /fiduswriter
+
 RUN mkdir static-libs
 RUN cp configuration.py-default configuration.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,18 +30,18 @@ RUN groupadd \
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get
 RUN apt-get update \
     && apt-get install -y \
-        wget \
-        unzip \
-        libjpeg-dev \
-        python-dev \
-        python-virtualenv \
         gettext \
-        zlib1g-dev \
         git \
-        npm \
+        libjpeg-dev \
         nodejs \
         nodejs-legacy \
+        npm \
+        python-dev \
         python-pip \
+        python-virtualenv \
+        unzip \
+        wget \
+        zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Download fiduswriter release from github

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ Until you define a mail-server (also through /data/configuration.py), the mails 
 
 In order to persist data, you __must grant write access for the executing user (fiduswriter)__ to the data directory that you want to map to on the host. This can be achieved by issuing the command below. If you do not ensure access to the desired directory on the host, fiduswriter will not run correctly.
 ~~~~
-$ sudo chmod -R 777 /host/directory
-
-or alternatively do proper user management instead of using the hammer ;)
+$ sudo chown -R 999:999 /host/directory
 ~~~~
 (Replace "/host/directory" with a valid directory on your host machine)
 


### PR DESCRIPTION
I didn't really like creating a publicly writeable directory on my server, so I figured out the user and group ID of the `fiduswriter` user and pinned down that number in the build process.

The user and group ID are now pinned on `999`, so the `data/` directory no longer needs to be fully public.

Furthermore, I added the following [best practices][1] to the [`Dockerfile`][2], should make the downloads slightly smaller:

- Joined `apt-get update` and `apt-get install`, and added a delete command for the downloaded information
- Sorted `apt-get install` packages
- made `WORKDIR` directive absolute
- squashed `RUN` statements for the application install and directory creation
- Use of array format for `CMD`, instead of the string format.

And I added that `chown 999:999` line to the [readme][3].

I split the changes up in rather small commits. I hope that's okay.

[1]: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices
[2]: https://github.com/roelofr/docker-fiduswriter/blob/master/Dockerfile
[3]: https://github.com/roelofr/docker-fiduswriter/blob/master/README.md